### PR TITLE
Feat/1 cluster cloudsql proxy

### DIFF
--- a/gcp/templates/cloudsql-proxy/deployment.yaml
+++ b/gcp/templates/cloudsql-proxy/deployment.yaml
@@ -1,0 +1,43 @@
+{{ if .Values.gcp.standaloneCloudSqlProxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-sql-proxy
+  labels:
+    app: cloud-sql-proxy
+spec:
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: cloud-sql-proxy
+  template:
+    metadata:
+      labels:
+        app: cloud-sql-proxy
+    spec:
+      terminationGracePeriodSeconds: 300
+      {{- with .Values.datacater.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "datacater.serviceAccountName" . }}
+      restartPolicy: Always
+      volumes:
+        - name: google-cloudsql-key
+          secret:
+            secretName: {{ .Values.gcp.standaloneCloudSqlProxy.cloudSqlKey }}
+      containers:
+        - name: cloud-sql-proxy
+          image: "gcr.io/cloudsql-docker/gce-proxy:{{- .Values.gcp.cloudSqlProxyVersion -}}"
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances={{ .Values.gcp.standaloneCloudSqlProxy.cloudSqlInstances }}=tcp:5432"
+            - "-credential_file=/secrets/key.json"
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /secrets/
+              name: google-cloudsql-key
+              readOnly: true
+{{ end }}

--- a/gcp/templates/cloudsql-proxy/deployment.yaml
+++ b/gcp/templates/cloudsql-proxy/deployment.yaml
@@ -16,11 +16,6 @@ spec:
       labels:
         app: cloud-sql-proxy
     spec:
-      terminationGracePeriodSeconds: 300
-      {{- with .Values.datacater.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       serviceAccountName: {{ include "datacater.serviceAccountName" . }}
       restartPolicy: Always
       volumes:
@@ -30,9 +25,11 @@ spec:
       containers:
         - name: cloud-sql-proxy
           image: "gcr.io/cloudsql-docker/gce-proxy:{{- .Values.gcp.cloudSqlProxyVersion -}}"
+          ports:
+            - containerPort: {{ .Values.gcp.standaloneCloudSqlProxy.targetPort }}
           command:
             - "/cloud_sql_proxy"
-            - "-instances={{ .Values.gcp.standaloneCloudSqlProxy.cloudSqlInstances }}=tcp:5432"
+            - "-instances={{ .Values.gcp.standaloneCloudSqlProxy.cloudSqlInstances }}=tcp:{{ .Values.gcp.standaloneCloudSqlProxy.targetPort }}"
             - "-credential_file=/secrets/key.json"
           securityContext:
             runAsNonRoot: true
@@ -41,3 +38,4 @@ spec:
               name: google-cloudsql-key
               readOnly: true
 {{ end }}
+

--- a/gcp/templates/cloudsql-proxy/service.yaml
+++ b/gcp/templates/cloudsql-proxy/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: {{ .Values.gcp.standaloneCloudSqlProxy.targetPort }}
       protocol: TCP
       name: http
 {{- end -}}

--- a/gcp/templates/cloudsql-proxy/service.yaml
+++ b/gcp/templates/cloudsql-proxy/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.gcp.standaloneCloudSqlProxy.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud-sql-proxy
+  labels:
+    app: cloud-sql-proxy
+spec:
+  selector:
+    app: cloud-sql-proxy
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+{{- end -}}

--- a/gcp/templates/platform/platform-deployment.yaml
+++ b/gcp/templates/platform/platform-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             failureThreshold: 30
             periodSeconds: 300
         - name: cloud-sql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.27.0
+          image: "gcr.io/cloudsql-docker/gce-proxy:{{- .Values.gcp.cloudSqlProxyVersion -}}"
           command:
             - "/cloud_sql_proxy"
             - "-instances={{ .Values.gcp.cloudSqlInstance }}=tcp:5432"

--- a/gcp/values.yaml
+++ b/gcp/values.yaml
@@ -10,6 +10,16 @@ gcp:
   ingressClass: "gce"
   # GCP static ip address name for datacater to keep fixed ip's on new deployments
   addressName: datacater-gcp-ip
+  # cloudSql-proxy version
+  cloudSqlProxyVersion: "1.27.0"
+  # GCP cloudSQL-proxy as standalone service for connecting to CloudSQL instances without firewall rules
+  standaloneCloudSqlProxy:
+    enabled: true
+    cloudSqlInstances: ""
+    # Secrets containing service account json. Defaults to cloudSqlProxy sidecar config. Can be changed.
+    cloudSqlKey: datacater-key
+    serviceAccountKey: datacater-key
+
 
 datacater:
   # Image pull secret name for datacater registry: images.datacater.io

--- a/gcp/values.yaml
+++ b/gcp/values.yaml
@@ -19,6 +19,8 @@ gcp:
     # Secrets containing service account json. Defaults to cloudSqlProxy sidecar config. Can be changed.
     cloudSqlKey: datacater-key
     serviceAccountKey: datacater-key
+    # Target DB port defaults postgresql default
+    targetPort: 5432
 
 
 datacater:


### PR DESCRIPTION
This PR introduces the ability to use a standalone cloudSQL proxy. If your GKE cluster does not use a private VPC or WorkloadIdentity, but you need to connect to an CloudSQL database this feature allows you to connect via an cloudSQL proxy and a service account to your cloud sql database.