### PR TITLE
fix(cloudsql): proxy now allows clusterwide connection

### DIFF
--- a/gcp/templates/cloudsql-proxy/deployment.yaml
+++ b/gcp/templates/cloudsql-proxy/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - containerPort: {{ .Values.gcp.standaloneCloudSqlProxy.targetPort }}
           command:
             - "/cloud_sql_proxy"
-            - "-instances={{ .Values.gcp.standaloneCloudSqlProxy.cloudSqlInstances }}=tcp:{{ .Values.gcp.standaloneCloudSqlProxy.targetPort }}"
+            - "-instances={{ .Values.gcp.standaloneCloudSqlProxy.cloudSqlInstances }}=tcp:0.0.0.0:{{ .Values.gcp.standaloneCloudSqlProxy.targetPort }}"
             - "-credential_file=/secrets/key.json"
           securityContext:
             runAsNonRoot: true

--- a/gcp/templates/platform/platform-deployment.yaml
+++ b/gcp/templates/platform/platform-deployment.yaml
@@ -17,7 +17,6 @@ spec:
       labels:
         app: datacater-platform
     spec:
-      terminationGracePeriodSeconds: 300
       {{- with .Values.datacater.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
cloudsql proxy allows connection from localhost by default.
To open cluster-wide 0.0.0.0 has to be set as a string
before the port.

https://github.com/GoogleCloudPlatform/cloudsql-proxy#tcp-socket-example

Refs: #1