### PR TITLE
feat(connect): make connect cluster resources configurable

### DIFF
--- a/gcp/templates/kafka/kafka-connect.yaml
+++ b/gcp/templates/kafka/kafka-connect.yaml
@@ -5,13 +5,8 @@ metadata:
 spec:
   version: 2.8.0
   resources:
-    requests:
-      cpu: 0.5
-      memory: 6Gi
-    limits:
-      cpu: 0.5
-      memory: 6Gi
-  replicas: 2
+    {{- toYaml .Values.datacater.connect.resources | nindent 4 }}
+  replicas: {{ .Values.datacater.connect.replicas }}
   bootstrapServers: datacater-kafka-bootstrap:9093
   livenessProbe:
     initialDelaySeconds: 120

--- a/gcp/values.yaml
+++ b/gcp/values.yaml
@@ -44,7 +44,6 @@ datacater:
         cpu: 0.5
         memory: 6Gi
       limits:
-        cpu: 0.5
         memory: 6Gi
 
 # DataCater uses a service called udf-runner for enabling interactive python development

--- a/gcp/values.yaml
+++ b/gcp/values.yaml
@@ -37,7 +37,15 @@ datacater:
   imagePullPolicy: Always
   # Used for Google Cloud ManagedCert and From field in mails.
   publicDomainName: datacater.example.com
-
+  connect:
+    replicas: 2
+    resources:
+      requests:
+        cpu: 0.5
+        memory: 6Gi
+      limits:
+        cpu: 0.5
+        memory: 6Gi
 
 # DataCater uses a service called udf-runner for enabling interactive python development
 udfRunner:


### PR DESCRIPTION
## Description

Tested with diff on rendered templates via

```bash
$ helm template gcp -f example-values/gcp-values.yaml > ../template-after.yaml
```

```bash
$ diff ../template-before.yaml ../template-after.yaml                                                                                        datacater-cloud-staging
519c519
<     requests:
---
>     limits:
522c522
<     limits:
---
>     requests:
```


