### PR TITLE
Allow kafka resource definition via values

### DIFF
--- a/gcp/templates/kafka/kafka.yaml
+++ b/gcp/templates/kafka/kafka.yaml
@@ -4,8 +4,10 @@ metadata:
   name: datacater
 spec:
   kafka:
+    resources:
+      {{- toYaml .Values.datacater.kafka.resources | nindent 6 }}
     version: 2.8.0
-    replicas: 3
+    replicas: {{ .Values.datacater.kafka.replicas }}
     listeners:
       - name: plain
         port: 9092

--- a/gcp/values.yaml
+++ b/gcp/values.yaml
@@ -44,6 +44,7 @@ datacater:
         cpu: 0.5
         memory: 6Gi
       limits:
+        cpu: 0.5
         memory: 6Gi
 
 # DataCater uses a service called udf-runner for enabling interactive python development

--- a/gcp/values.yaml
+++ b/gcp/values.yaml
@@ -37,6 +37,14 @@ datacater:
   imagePullPolicy: Always
   # Used for Google Cloud ManagedCert and From field in mails.
   publicDomainName: datacater.example.com
+  kafka:
+    replicas: 3
+    resources:
+      requests:
+        cpu: 0.5
+        memory: 6Gi
+      limits:
+        memory: 6Gi
   connect:
     replicas: 2
     resources:

--- a/gcp/values.yaml
+++ b/gcp/values.yaml
@@ -44,7 +44,6 @@ datacater:
         cpu: 0.5
         memory: 6Gi
       limits:
-        cpu: 0.5
         memory: 6Gi
 
 # DataCater uses a service called udf-runner for enabling interactive python development


### PR DESCRIPTION
Tested against staging cluster with created resource looking like:

```yaml
apiVersion: kafka.strimzi.io/v1beta2
kind: Kafka
metadata:
  name: datacater
spec:
  kafka:
    resources:
      limits:
        memory: 6Gi
      requests:
        cpu: 0.5
        memory: 6Gi
    version: 2.8.0
    replicas: 3
    listeners:
      - name: plain
        port: 9092
        type: internal
        tls: false
      - name: tls
        port: 9093
        type: internal
        tls: true
    config:
      offsets.topic.replication.factor: 1
      transaction.state.log.replication.factor: 1
      transaction.state.log.min.isr: 1
      log.message.format.version: "2.8"
      inter.broker.protocol.version: "2.8"
      message.max.bytes: "3145728"
      replica.fetch.max.bytes: "3145728"
    storage:
      type: persistent-claim
      size: 500Gi
  zookeeper:
    replicas: 3
    storage:
      type: persistent-claim
      size: 20Gi
  entityOperator:
    topicOperator: {}
    userOperator: {}

```