### PR TITLE
Configuration changes for platform and registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
-.env
+*.env
 .dev
+

--- a/eks/templates/_helpers.tpl
+++ b/eks/templates/_helpers.tpl
@@ -107,6 +107,11 @@ Helper function for getting env variables for platform
     configMapKeyRef:
         name: datacater-platform-config
         key: kafka_port
+- name: PG_DATABASE_NAME
+  valueFrom:
+    configMapKeyRef:
+        name: datacater-platform-config
+        key: pg_database_name
 - name: PG_HOST
   valueFrom:
     configMapKeyRef:

--- a/eks/templates/platform/platform-configmap.yaml
+++ b/eks/templates/platform/platform-configmap.yaml
@@ -20,6 +20,7 @@ data:
   pipeline_registry: {{ required "Required .Values.datacater.pipelineRegistry: example myregistry.fordatacater.io. Used to push and pull images from" .Values.datacater.pipelineRegistry }}
   deployment_type: {{ .Values.platform.envConfigMap.deploymentType | quote }}
   pg_host: {{ .Values.platform.envConfigMap.pgHost }}
+  pg_database_name: {{ .Values.platform.envConfigMap.pgDatabaseName | default "datacater" }}
   dc_chart_version: {{ .Chart.Version | quote}}
   mailer_tls: {{ .Values.platform.envConfigMap.mailerTLS | default "no" | quote }}
   mailer_ssl: {{ .Values.platform.envConfigMap.mailerSSL | default "no" | quote }}

--- a/eks/values.yaml
+++ b/eks/values.yaml
@@ -46,7 +46,8 @@ platform:
     kafkaPort: "9092"
     kafkaConnectHost: datacater-connect-api
     kafkaConnectPort: "8083"
-    pgHost: "127.0.0.1:5432"
+    pgHost: "127.0.0.1"
+    pgDatabaseName: "datacater"
     deploymentType: k8
     mailerTLS: "no"
     mailerSSL: "no"

--- a/example-values/eks-values.yaml
+++ b/example-values/eks-values.yaml
@@ -1,8 +1,8 @@
 datacater:
   publicDomainName: datacater.example.com
   # Elastic Container Registyr is used for storing pipeline images.
-  # pipelineRegistry: $account_id.dkr.ecr.$region.amazonaws.com
-  pipelineRegistry: 193290265706.dkr.ecr.eu-central-1.amazonaws.com
+  # pipelineRegistry: $account_id.dkr.ecr.$region.amazonaws.com/repository
+  pipelineRegistry: 000000000000.dkr.ecr.eu-central-1.amazonaws.com/repository
   kafka:
     replicas: 3
     resources:


### PR DESCRIPTION
This PR includes two significant changes:

1. It allows for configuration of the database to be used via `.Values.platform.envConfigMap.pgDatabaseName`.

2. It allows the configuration of a pipeline registry via environment variables only.

3. Adjust gcp env variables to reflect the naming change.